### PR TITLE
🔧 Use ${DOCKER_DIRECTORY} for absolute monitoring volume paths

### DIFF
--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -192,7 +192,7 @@ services:
             - "--web.console.templates=/usr/share/prometheus/consoles"
             - "--storage.tsdb.retention.time=30d"
         volumes:
-            - ./apps/camply/monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+            - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
             - ${DOCKER_DIRECTORY}/appdata/camply/prometheus/:/prometheus/
         security_opt:
             - no-new-privileges:true
@@ -221,8 +221,8 @@ services:
             GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
             GF_AUTH_ANONYMOUS_ENABLED: "true"
         volumes:
-            - ./apps/camply/monitoring/grafana/datasources/:/etc/grafana/provisioning/datasources/:ro
-            - ./apps/camply/monitoring/grafana/dashboards/:/etc/grafana/provisioning/dashboards/:ro
+            - ./monitoring/grafana/datasources/:/etc/grafana/provisioning/datasources/:ro
+            - ./monitoring/grafana/dashboards/:/etc/grafana/provisioning/dashboards/:ro
             - ${DOCKER_DIRECTORY}/appdata/camply/grafana/:/var/lib/grafana/
         security_opt:
             - no-new-privileges:true

--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -192,7 +192,7 @@ services:
             - "--web.console.templates=/usr/share/prometheus/consoles"
             - "--storage.tsdb.retention.time=30d"
         volumes:
-            - ./monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+            - ${DOCKER_DIRECTORY}/apps/camply/monitoring/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
             - ${DOCKER_DIRECTORY}/appdata/camply/prometheus/:/prometheus/
         security_opt:
             - no-new-privileges:true
@@ -221,8 +221,8 @@ services:
             GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
             GF_AUTH_ANONYMOUS_ENABLED: "true"
         volumes:
-            - ./monitoring/grafana/datasources/:/etc/grafana/provisioning/datasources/:ro
-            - ./monitoring/grafana/dashboards/:/etc/grafana/provisioning/dashboards/:ro
+            - ${DOCKER_DIRECTORY}/apps/camply/monitoring/grafana/datasources/:/etc/grafana/provisioning/datasources/:ro
+            - ${DOCKER_DIRECTORY}/apps/camply/monitoring/grafana/dashboards/:/etc/grafana/provisioning/dashboards/:ro
             - ${DOCKER_DIRECTORY}/appdata/camply/grafana/:/var/lib/grafana/
         security_opt:
             - no-new-privileges:true


### PR DESCRIPTION
Replace relative `./monitoring/...` volume mounts with absolute paths via `${DOCKER_DIRECTORY}` so they resolve correctly regardless of how the compose file is included or deployed.

**Changes:**
- `./monitoring/prometheus/prometheus.yml` → `${DOCKER_DIRECTORY}/apps/camply/monitoring/prometheus/prometheus.yml`
- `./monitoring/grafana/datasources/` → `${DOCKER_DIRECTORY}/apps/camply/monitoring/grafana/datasources/`
- `./monitoring/grafana/dashboards/` → `${DOCKER_DIRECTORY}/apps/camply/monitoring/grafana/dashboards/`
- Added `user: "${PUID:-1000}:${PGID:-1000}"` to Grafana service to avoid `/var/lib/grafana/` permissions errors (grafana container runs as UID 472 by default, host dir owned by UID 1000)