### PR TITLE
🐛 (camply): Add user directive to Grafana service for volume permissions

### DIFF
--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -213,6 +213,7 @@ services:
     camply-grafana:
         image: grafana/grafana:latest
         container_name: camply-grafana
+        user: "${PUID:-1000}:${PGID:-1000}"
         depends_on:
             camply-prometheus:
                 condition: service_started


### PR DESCRIPTION
Grafana runs as UID 472 by default, but the host directory at `${DOCKER_DIRECTORY}/appdata/camply/grafana/` is owned by UID 1000 (the host user). This causes `mkdir: can't create directory '/var/lib/grafana/plugins': Permission denied` on startup when Grafana tries to write plugins, the embedded SQLite DB, or other runtime data.

**Fix:** Add `user: "${PUID:-1000}:${PGID:-1000}"` to the Grafana service so it runs as the host user and can write to the mounted volume.