### PR TITLE
🐛 (camply): Fix Grafana user directive for bind mount compatibility

### DIFF
--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -213,7 +213,7 @@ services:
     camply-grafana:
         image: grafana/grafana:latest
         container_name: camply-grafana
-        user: "${PUID:-1000}:${PGID:-1000}"
+        user: '0'
         depends_on:
             camply-prometheus:
                 condition: service_started


### PR DESCRIPTION
Grafana changed the default container user from root to UID 472 in v5.1. When using bind mounts with a host directory owned by UID 1000, the container needs to run as root (`user: "0"`) to write to `/var/lib/grafana/`.

**Ref:** https://grafana.com/docs/grafana/latest/setup-grafana/installation/docker/#migrate-to-v51-or-later

**Previous fix (PR #712)** used `${PUID:-1000}:${PGID:-1000}` which doesn't match Grafana's internal UID 472 and can cause permission issues with Grafana's own config files that are owned by UID 472 inside the image.