### PR TITLE
🐛 (camply): Fix Prometheus user directive for bind mount compatibility

### DIFF
--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -185,6 +185,7 @@ services:
     camply-prometheus:
         image: prom/prometheus:latest
         container_name: camply-prometheus
+        user: '0'
         command:
             - "--config.file=/etc/prometheus/prometheus.yml"
             - "--storage.tsdb.path=/prometheus"


### PR DESCRIPTION
Prometheus container runs as UID 65534 (nobody) by default, but the host-mounted `/prometheus/` volume is owned by UID 1000, causing:

```
level=ERROR source=query_logger.go:113 msg="Error opening query log file" component=activeQueryTracker file=/prometheus/queries.active err="open /prometheus/queries.active: permission denied"
panic: Unable to create mmap-ed active query log
```

**Fix:** Add `user: "0"` to the Prometheus service so it runs as root inside the container and can write to the bind-mounted data directory.

(Same approach as the Grafana fix in #713.)