### PR TITLE
🔐 (camply): Enable Auth0 OAuth for production deployment

### DIFF
--- a/apps/camply/docker-compose.yaml
+++ b/apps/camply/docker-compose.yaml
@@ -75,6 +75,11 @@ services:
             GUNICORN_WORKERS: ${GUNICORN_WORKERS:-4}
             PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
             CAMPLY_PROMETHEUS_MULTIPROC_DIR: /tmp/prometheus_multiproc
+            CAMPLY_ENVIRONMENT: production
+            CAMPLY_AUTH_MODE: auth0
+            CAMPLY_AUTH0_DOMAIN: ${CAMPLY_AUTH0_DOMAIN}
+            CAMPLY_AUTH0_AUDIENCE: ${CAMPLY_AUTH0_AUDIENCE}
+            CAMPLY_AUTH0_CLIENT_ID: ${CAMPLY_AUTH0_CLIENT_ID}
         security_opt:
             - no-new-privileges:true
         restart: ${UNIVERSAL_RESTART_POLICY:-unless-stopped}


### PR DESCRIPTION
The camply-web backend and frontend already have full Auth0 support built in (backend has jwt validation + upserter, frontend uses `@auth0/auth0-react` with `Auth0Provider`). This just flips the switch for the production deployment.

**Changes to `apps/camply/docker-compose.yaml`:**

- `CAMPLY_ENVIRONMENT: production` — for Sentry/logging context
- `CAMPLY_AUTH_MODE: auth0` — enables JWT validation on the backend
- `CAMPLY_AUTH0_DOMAIN`, `CAMPLY_AUTH0_AUDIENCE`, `CAMPLY_AUTH0_CLIENT_ID` — passed through from `.env.yaml`

**You'll need to add to `.env.yaml` (sops):**
  - `CAMPLY_AUTH0_DOMAIN`
  - `CAMPLY_AUTH0_AUDIENCE`
  - `CAMPLY_AUTH0_CLIENT_ID`

After merging, the frontend will fetch `/api/auth-config`, see `auth_mode: "auth0"`, and render the Auth0 login flow. The backend will require valid RS256 JWTs on protected endpoints.